### PR TITLE
docs: add llamaindex expert example

### DIFF
--- a/examples/llamaindex-expert/.mcp.json
+++ b/examples/llamaindex-expert/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "llamaindex-docs": {
+      "url": "https://developers.llamaindex.ai/mcp",
+      "headers": {}
+    }
+  }
+}

--- a/examples/llamaindex-expert/README.md
+++ b/examples/llamaindex-expert/README.md
@@ -1,0 +1,11 @@
+# LlamaIndex Expert
+
+The [agent_config.yaml](./agent_config.yaml) and the [.mcp.json](./.mcp.json) files available in this folder can be used to create a LlamaIndex expert assistant to build typescript and python applications, thanks to the [Documentation MCP](https://www.llamaindex.ai/blog/adding-native-mcp-to-llamaindex-docs) offered by LlamaIndex.
+
+The agent has also access to memory tools (to store important pieces of information gathered during exploration or deriving from user interaction) and TODO tools (to track its tasks).
+
+Example prompt:
+
+```md
+Could you please create an example LlamaIndex Workflow in typescript, using the fan-in/fan-out pattern?
+```

--- a/examples/llamaindex-expert/agent_config.yaml
+++ b/examples/llamaindex-expert/agent_config.yaml
@@ -1,0 +1,15 @@
+agent_task: Help the user with writing python and typescript code powered by the LlamaIndex framework, workflows and LlamaCloud platform services. Do so by accessing MCP tools from the `llamaindex-docs` MCP server, as well as by leveraging filesystem-based tools for reading, writing and file searching operations. Use memory tools to store important pieces of information gathered during exploration or deriving from user interaction, and use todo tools to keep track of your tasks.
+mode: ask
+model: gemini-3-flash-preview
+tools:
+  - describe_dir_content
+  - read_file
+  - grep_file_content
+  - glob_paths
+  - write_file
+  - edit_file
+  - write_memory
+  - read_memory
+  - create_todos
+  - list_todos
+  - update_todos


### PR DESCRIPTION
Add an example for a LlamaIndex Expert Agent to assist people in building typescript/python app backed by the documentation MCP
